### PR TITLE
remove stories from coverage, no errors when collecting from js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "react-scripts-ts build",
     "predeploy": "yarn build",
     "deploy": "gh-pages -d build",
-    "test": "react-scripts-ts test --env=jsdom --coverage",
+    "test": "react-scripts-ts test --env=jsdom --coverage --collectCoverageFrom='[\"src/**/*.{tsx,js,ts,jsx}\",\"!src/**/*.story.tsx\", \"!src/registerServiceWorker.js\", \"!src/index.js\"]'",
     "eject": "react-scripts-ts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/package.json
+++ b/package.json
@@ -20,10 +20,20 @@
     "build": "react-scripts-ts build",
     "predeploy": "yarn build",
     "deploy": "gh-pages -d build",
-    "test": "react-scripts-ts test --env=jsdom --coverage --collectCoverageFrom='[\"src/**/*.{tsx,js,ts,jsx}\",\"!src/**/*.story.tsx\", \"!src/registerServiceWorker.js\", \"!src/index.js\"]'",
+    "test": "react-scripts-ts test --env=jsdom --coverage",
     "eject": "react-scripts-ts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!<rootDir>/node_modules/",
+      "!src/**/*.story.{js,jsx,ts,tsx}",
+      "!src/index.{ts,tsx}",
+      "!src/**/*Mocks.{ts,tsx}",
+      "!src/registerServiceWorker.{ts,tsx}"
+    ]
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.14",


### PR DESCRIPTION
- remove stories from coverage
- no more errors when trying to collect coverage from registerServiceWorker.js and index.js