### PR TITLE
Add Netlify Redirect URL

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/ultimate-tic-tac-react/*         /:splat         200


### PR DESCRIPTION
To get Netlify to work with the correct URLs and still be able to use GitHub Pages I added a redirect url.
For now I want to still be able to use GitHub Pages because some (important) links still link to it. This is the easiest way to do just that.